### PR TITLE
Payroll tab hide

### DIFF
--- a/src/js/PrivateLayout.js
+++ b/src/js/PrivateLayout.js
@@ -117,7 +117,7 @@ class PrivateLayout extends Flux.DashView {
     this.currentPath = null;
     this.removeHistoryListener = null;
     this.state = {
-      showHideHR: true,
+      showHide: true,
       showRightBar: 0,
       showButtonBar: true,
       loading: true,
@@ -690,7 +690,7 @@ class PrivateLayout extends Flux.DashView {
   }
 
   render() {
-    const { showHideHR } = this.state;
+    const { showHide } = this.state;
     if (
       this.state.employer &&
       this.state.employer.active_subscription &&
@@ -763,7 +763,7 @@ class PrivateLayout extends Flux.DashView {
                 </NavLink>
               </li>
               <li>
-                {showHideHR && (
+                {showHide && (
                   <NavLink to="/talents">
                     <i className="icon icon-talents"></i>
                     <span style={{ fontSize: 16, fontWeight: 500 }}>
@@ -788,7 +788,7 @@ class PrivateLayout extends Flux.DashView {
                   </span>
                 </NavLink>
               </li>
-              {this.showPayroll()}
+              {showHide && (this.showPayroll())}
               <li>
                 <NavLink to="/profile" id="profilelink">
                   <i className="icon icon-companyprofile"></i>
@@ -1233,9 +1233,9 @@ class PrivateLayout extends Flux.DashView {
     );
   }
   hideComponent(admin) {
-    if (admin==="hradmin@jobcore.co") {
-      // this.setState({ showHideHR: false }); // uncommenting makes tap talent search is visible only to JC-HR@admin.co
-      console.log("showHideHR###", this.state.showHideHR)
+    if (admin!="hradmin@jobcore.co") {
+      this.setState({ showHide: false }); // uncommenting makes tap talent search is visible only to JC-HR@admin.co
+      console.log("showHide###", this.state.showHide)
       console.log("admin###", admin)
     } 
   }

--- a/src/js/sum.js
+++ b/src/js/sum.js
@@ -1,4 +1,0 @@
-function sum(a, b) {
-	return a + b;
-  }
-  module.exports = sum;

--- a/src/js/sum.test.js
+++ b/src/js/sum.test.js
@@ -1,5 +1,0 @@
-const sum = require('./sum');
-
-test('adds 1 + 2 to equal 3', () => {
-  expect(sum(1, 2)).toBe(3);
-});


### PR DESCRIPTION
Since the logic to execute payroll is not quite ready and we want to launch the app, this commit hides the payroll tab so that the user does not try unsuccessfully to use it, avoiding bad user experiences and complaints.